### PR TITLE
fix: add permissions section for tray-check.yml contents read access

### DIFF
--- a/.github/workflows/tray-check.yml
+++ b/.github/workflows/tray-check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check-tray-imports:
     runs-on: windows-latest


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration by setting explicit permissions for the workflow. This helps improve security by limiting the workflow's access to repository contents.

* Security improvement:
  * [`.github/workflows/tray-check.yml`](diffhunk://#diff-59e2660ed17b08a39ed58939a24a209e2fb1e6f3e7774099290f01eb4c3fdf9eR9-R11): Added `permissions` block to restrict workflow access to read-only for repository contents.